### PR TITLE
Add missing chip header in FreeRTOS context

### DIFF
--- a/stm32/libuavcan/driver/include/uavcan_stm32/thread.hpp
+++ b/stm32/libuavcan/driver/include/uavcan_stm32/thread.hpp
@@ -18,6 +18,7 @@
 # include <cstring>
 #elif UAVCAN_STM32_BAREMETAL
 #elif UAVCAN_STM32_FREERTOS
+# include <chip.h>
 # include <cmsis_os.h>
 #else
 # error "Unknown OS"


### PR DESCRIPTION
Otherwise thread.hpp doesn't compile because SemaphoreHandle_t is not defined.
Using chip.h header, where FreeRTOS related header are defined, should fix it.